### PR TITLE
ci: use new public action for pre-commit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,29 +16,8 @@ jobs:
     name: Precommit checks
     runs-on: ubuntu-latest
     steps:
-      - name: "Checkout code"
-        uses: actions/checkout@v4
-
-      - name: "Setup Python"
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: "Install pre-commit"
-        run: python -m pip install pre-commit==${{ env.PRE_COMMIT_VERSION }}
-        shell: bash
-
-      - run: python -m pip freeze --local
-        shell: bash
-
-      - uses: actions/cache@v4
-        with:
-          path: ~/.cache/pre-commit
-          key: pre-commit-${{ env.PRE_COMMIT_VERSION }}|${{ hashFiles('.pre-commit-config.yaml') }}
-
-      - name: "Run pre-commit checks"
-        run: pre-commit run --show-diff-on-failure --color=always
-        shell: bash
+      - uses: actions/checkout@v4
+      - uses: griceturrble/precommit-checks-action@v1
 
   test:
     name: Run Tests


### PR DESCRIPTION
Why keep reinventing the wheel?